### PR TITLE
fix: should be calling callback not cb

### DIFF
--- a/routes/accounts.js
+++ b/routes/accounts.js
@@ -13,7 +13,7 @@ router.get('/:offset?', function(req, res, next) {
     function(callback) {
       web3.eth.getBlock('latest', function(err, result) {
         if (err) {
-          cb(err, null)
+          callback(err, null)
           return
         }
 


### PR DESCRIPTION
the accounts page is currently trying to call `cb` but the correct name for the callback function is `callback`. Fixes https://github.com/ewasm/etherchain-light/issues/6