### PR TITLE
get pending block in order to get the pending transactions

### DIFF
--- a/routes/tx.js
+++ b/routes/tx.js
@@ -14,8 +14,10 @@ router.get('/pending', function(req, res, next) {
   
   async.waterfall([
     function(callback) {
-      web3.parity.pendingTransactions(function(err, result) {
-        callback(err, result);
+      var txs = [];
+      web3.eth.getBlock('pending', true, function(err, block) {
+        txs = block.transactions;
+        callback(err, txs);
       });
     }
   ], function(err, txs) {


### PR DESCRIPTION
get pending block and its transactions instead of calling parity's rpc method.

fixes: https://github.com/ewasm/etherchain-light/issues/4