### PR TITLE
Separate byte code from wastcode and storage

### DIFF
--- a/views/account.pug
+++ b/views/account.pug
@@ -20,7 +20,7 @@ block content
         a(href='#transactions', aria-controls='transactions', role='tab', data-toggle='tab') Transactions
       if account.isContract
         li(role='presentation')
-          a(href='#code', aria-controls='code', role='tab', data-toggle='tab') Code
+          a(href='#code', aria-controls='code', role='tab', data-toggle='tab') Bytecode
         li(role='presentation')
           a(href='#wastcode', aria-controls='wastcode', role='tab', data-toggle='tab') Wast Code
         li(role='presentation')
@@ -93,7 +93,7 @@ block content
       
       if account.isContract
         #code.tab-pane(role='tabpanel')
-          h3 Code
+          h3 Bytecode
           if !account.source
             a(href="/contract/verify") Upload source
           pre #{account.code}

--- a/views/account.pug
+++ b/views/account.pug
@@ -21,6 +21,10 @@ block content
       if account.isContract
         li(role='presentation')
           a(href='#code', aria-controls='code', role='tab', data-toggle='tab') Code
+        li(role='presentation')
+          a(href='#wastcode', aria-controls='wastcode', role='tab', data-toggle='tab') Wast Code
+        li(role='presentation')
+          a(href='#storage', aria-controls='storage', role='tab', data-toggle='tab') Storage  
       if account.source
         li(role='presentation')
           a(href='#source', aria-controls='source', role='tab', data-toggle='tab') Source
@@ -93,9 +97,11 @@ block content
           if !account.source
             a(href="/contract/verify") Upload source
           pre #{account.code}
-          if account.wast
-            h3 Wast code
-            pre(class="wast") #{account.wast}
+      if account.wast
+        #wastcode.tab-pane(role='tabpanel')  
+          h3 Wast code
+          pre(class="wast") #{account.wast}
+        #storage.tab-pane(role='tabpanel')
           h3 Storage
           pre #{JSON.stringify(account.storage, undefined, 2)}
       if account.source


### PR DESCRIPTION
When the contract byte code is very long you have to scroll down to be able to see the wastcode and storage. This PR separates wastcode and storage into different tabs.