### PR TITLE
set gasUsed to 0, when tx is still pending

### DIFF
--- a/routes/tx.js
+++ b/routes/tx.js
@@ -165,6 +165,8 @@ router.get('/:tx', function(req, res, next) {
       if (!tx.to) {
         tx.contractAddress = receipt.contractAddress;
       }
+    } else {
+      tx.gasUsed = 0;
     }
 
     if (traces != null) {


### PR DESCRIPTION
This avoids exception in ethformatter when gasUsed is not set due to transaction is still pending. Fixes https://github.com/ewasm/etherchain-light/issues/77