### PR TITLE
Check addresss is not undefined when formatting

### DIFF
--- a/views/tx.pug
+++ b/views/tx.pug
@@ -24,10 +24,12 @@ block content
       td
         if tx.to
           a(href="account/" + tx.to) #{nameformatter.format(tx.to)}
-        else
+        else if tx.contractAddress
           | New Contract (deployment address:
           a(href="account/" + tx.contractAddress) #{nameformatter.format(tx.contractAddress)}
           | )
+        else
+          | Pending contract deployment
     tr
       td Amount:
       td #{ethformatter(tx.value)}


### PR DESCRIPTION
avoid formatting an undefined address when new contract creation tx is still pending

```
TypeError: /home/hugo/workspace/etherchain-light/views/tx.pug:29
    27|         else
    28|           | New Contract (deployment address:
  > 29|           a(href="account/" + tx.contractAddress) #{nameformatter.format(tx.contractAddress)}
    30|           | )
    31|     tr
    32|       td Amount:

Cannot read property 'toLowerCase' of undefined
```